### PR TITLE
Cross compile for windows on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,10 @@ if (NOT WIN32)
     add_subdirectory(source/frontends/qt)
   endif()
 
-  if (BUILD_SA2)
-    add_subdirectory(source/frontends/sdl)
-  endif()
+endif()
 
+if (BUILD_SA2)
+  add_subdirectory(source/frontends/sdl)
 endif()
 
 file(STRINGS resource/version.h VERSION_FILE LIMIT_COUNT 1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use the official dockcross windows static x64 image as base
+FROM dockcross/windows-static-x64:latest
+
+# Install essential build tools inside the container (Debian-based)
+RUN apt-get update && apt-get install -y \
+    vim-common \
+    xxd \
+    build-essential \
+    patch \
+    unzip \
+    cmake \
+    python3 python3-pip python3-packaging \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build Boost and zlib using MXE
+RUN cd /usr/src/mxe && make boost zlib sdl2 sdl2_image libslirp
+
+# Optionally clean up to reduce image size (MXE build cache can be big)
+RUN rm -rf /usr/src/mxe/builds/* /tmp/*

--- a/README_linux.md
+++ b/README_linux.md
@@ -1,19 +1,20 @@
-# Building for linux
+# Building
 
 ## Additional libraries required
 
 The following libraries are required to be installed.
 
 ```
-| Library Name | Arch Package | Ubuntu Packages        |
-|--------------|--------------|------------------------|
-| SLIRP        | libslirp     | libslirp-dev           |
-|              |              | libslirp0              |
-| Boost        | boost        | libboost-all-dev       |
-| SDL2         | sdl2         | libsdl2-dev            |
-|              |              | libsdl2-2.0-0          |
-| SDL2_image   | sdl2_image   | libsdl2-image-dev      |
-|              |              | libsdl2-image-2.0-0    |
+| Library Name | Arch/MXE Package | Ubuntu Packages        |
+|--------------|------------------|------------------------|
+| SLIRP        | libslirp         | libslirp-dev           |
+|              |                  | libslirp0              |
+| Boost        | boost            | libboost-all-dev       |
+| SDL2         | sdl2             | libsdl2-dev            |
+|              |                  | libsdl2-2.0-0          |
+| SDL2_image   | sdl2_image       | libsdl2-image-dev      |
+|              |                  | libsdl2-image-2.0-0    |
+| ZLIB         | zlib             |                        |
 ```
 
 For Ubuntu users, you can install all required packages with:
@@ -21,10 +22,25 @@ For Ubuntu users, you can install all required packages with:
 sudo apt update && sudo apt install libslirp-dev libslirp0 libboost-all-dev libsdl2-dev libsdl2-2.0-0 libsdl2-image-dev libsdl2-image-2.0-0
 ```
 
-## building
+## building for linux
 
 ```bash
 git submodule update --init --recursive
 # c = clean, b = build. use -h for help
 ./build.sh -cb
 ```
+
+## cross compiling to windows
+
+```bash
+git submodule update --init --recursive
+# c = clean, b = build. use -h for help
+./build.sh -cbw
+```
+
+You can then run the binary under WINE with:
+
+```bash
+env -i DISPLAY=:0 XDG_SESSION_TYPE=x11 wine ./build/sa2.exe
+```
+The XDG env var is needed if you have wayland on your machine, the SDL2 library works for x11 under WINE.

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# A build script for AppleWin Linux
+# A build script for AppleWin Linux or Windows (via mingw-w64 cross-compile using Docker)
 #
 
 function show_help {
@@ -8,11 +8,12 @@ function show_help {
   echo ""
   echo "building options:"
   echo "   -b       # run build"
+  echo "   -w       # target Windows (cross-compile with mingw-w64 Docker)"
   echo ""
   echo "flags for building options"
   echo "   -c       # run clean before build"
   echo "   -g       # compile with debug enabled"
-  echo "   -G GEN   # Use GEN as the Generator for cmake (e.g. -G \"Unix Makefiles\" )"
+  echo "   -G GEN   # Use GEN as the Generator for cmake (e.g. -G \"Unix Makefiles\" or -G Ninja)"
   echo ""
   echo "other options:"
   echo "   -h       # this help"
@@ -23,64 +24,126 @@ function show_help {
   exit 1
 }
 
-if [ $# -eq 0 ] ; then
+if [ $# -eq 0 ]; then
   show_help
 fi
 
 DO_BUILD=0
 DO_CLEAN=0
+TARGET_WINDOWS=0
 RELEASE_TYPE="Release"
 CMAKE_GENERATOR=""
 
-while getopts "bcgG:h" flag
-do
+while getopts "bcgwG:h" flag; do
   case "$flag" in
-    b) DO_BUILD=1 ;;
-    c) DO_CLEAN=1 ;;
-    g) RELEASE_TYPE="Debug" ;;
-    G) CMAKE_GENERATOR=${OPTARG} ;;
-    h) show_help ;;
-    *) show_help ;;
+  b) DO_BUILD=1 ;;
+  c) DO_CLEAN=1 ;;
+  g) RELEASE_TYPE="Debug" ;;
+  w) TARGET_WINDOWS=1 ;;
+  G) CMAKE_GENERATOR=${OPTARG} ;;
+  h) show_help ;;
+  *) show_help ;;
   esac
 done
 shift $((OPTIND - 1))
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BUILD_DIR="$SCRIPT_DIR/build"
 
-if [ ! -d build ]; then
-  mkdir build
+# Create build directory if missing
+if [ ! -d "$BUILD_DIR" ]; then
+  mkdir "$BUILD_DIR"
 fi
 
-if [ $DO_CLEAN -eq 1 ] ; then
-  echo "Removing old build artifacts"
-  rm -rf $SCRIPT_DIR/build/*
-  rm $SCRIPT_DIR/build/.ninja* 2>/dev/null
-fi
+# If target Windows, we run inside the dockcross docker container
+if [ $TARGET_WINDOWS -eq 1 ]; then
+  DOCKER_IMAGE="ghcr.io/fujinetwifi/applewin-dockcross-windows-static-x64:latest"
 
-
-if [ $DO_BUILD -eq 1 ] ; then
-  echo "Building AppleWinLinux project"
-  cd $SCRIPT_DIR/build
-
-  GEN_CMD=""
-  if [ -n "$CMAKE_GENERATOR" ] ; then
-    GEN_CMD="-G $CMAKE_GENERATOR"
+  # Pull Docker image if missing locally
+  if ! docker image inspect "$DOCKER_IMAGE" > /dev/null 2>&1; then
+    echo "Docker image $DOCKER_IMAGE not found locally. Pulling from GHCR..."
+    docker pull "$DOCKER_IMAGE"
+    if [ $? -ne 0 ]; then
+      echo "Failed to pull Docker image $DOCKER_IMAGE. Aborting."
+      exit 1
+    fi
   fi
 
-  cmake "$GEN_CMD" .. -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DBUILD_SA2=on "$@"
+  # Get user id/group to avoid permission issues on mounted volumes
+  USER_ID=$(id -u)
+  GROUP_ID=$(id -g)
 
-  echo "Building for $RELEASE_TYPE"
-  cmake "$GEN_CMD" .. -DCMAKE_BUILD_TYPE=$RELEASE_TYPE -DBUILD_SA2=on "$@"
-  if [ $? -ne 0 ] ; then
-    echo "Error running initial cmake. Aborting"
-    exit 1
+  if [ $DO_CLEAN -eq 1 ]; then
+    echo "Cleaning build directory inside Docker container"
+    docker run --rm -u "$USER_ID:$GROUP_ID" -v "$SCRIPT_DIR":/work -w /work \
+      $DOCKER_IMAGE rm -rf build/*
   fi
 
-  cmake --build .
+  if [ $DO_BUILD -eq 1 ]; then
+    echo "Building AppleWin project for Windows inside Docker container"
 
-  if [ $? -ne 0 ]; then
-    echo "ERROR: Could not run cmake."
-    exit 1
+    GEN_CMD=()
+    if [ -n "$CMAKE_GENERATOR" ]; then
+      GEN_CMD+=("-G" "$CMAKE_GENERATOR")
+    fi
+
+    # Run cmake configure step inside container
+    docker run --rm -u "$USER_ID:$GROUP_ID" -v "$SCRIPT_DIR":/work -w /work/build \
+      $DOCKER_IMAGE \
+      x86_64-w64-mingw32.static-cmake "${GEN_CMD[@]}" .. \
+      -DBUILD_SA2=on \
+      -DCMAKE_BUILD_TYPE=$RELEASE_TYPE \
+      "$@"
+
+    if [ $? -ne 0 ]; then
+      echo "Error running cmake inside Docker container. Aborting"
+      exit 1
+    fi
+
+    # Run build inside container
+    docker run --rm -u "$USER_ID:$GROUP_ID" -v "$SCRIPT_DIR":/work -w /work/build \
+      $DOCKER_IMAGE \
+      cmake --build .
+
+    if [ $? -ne 0 ]; then
+      echo "ERROR: Could not build inside Docker container."
+      exit 1
+    fi
   fi
 
+else
+  # Native Linux build
+
+  if [ $DO_CLEAN -eq 1 ]; then
+    echo "Removing old build artifacts"
+    rm -rf "$BUILD_DIR"/*
+    rm "$BUILD_DIR"/.ninja* 2>/dev/null || true
+  fi
+
+  if [ $DO_BUILD -eq 1 ]; then
+    echo "Building AppleWin project for native Linux target"
+    cd "$BUILD_DIR"
+
+    GEN_CMD=""
+    if [ -n "$CMAKE_GENERATOR" ]; then
+      GEN_CMD="-G $CMAKE_GENERATOR"
+    fi
+
+    cmake $GEN_CMD .. \
+      -DBUILD_SA2=on \
+      -DCMAKE_BUILD_TYPE=$RELEASE_TYPE \
+      "$@"
+
+    if [ $? -ne 0 ]; then
+      echo "Error running cmake. Aborting"
+      exit 1
+    fi
+
+    cmake --build .
+
+    if [ $? -ne 0 ]; then
+      echo "ERROR: Could not run cmake."
+      exit 1
+    fi
+  fi
 fi

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -103,15 +103,15 @@ void LoadConfiguration(bool loadImages)
 	///////////////////////////////////////////////////////////////
 	// SmartPort over SLIP
 	auto& listener = GetCommandListener();
-	DWORD dwRegStartListener = 0;
+	uint32_t dwRegStartListener = 0;
 	bool bStartListener = listener.default_start_listener;
 
 	char tcAddress[16];
 	strncpy(tcAddress, listener.default_listener_address.data(), 15);
 	tcAddress[15] = '\0'; // ensure it's null terminated in worst case 111.111.111.111
 
-	DWORD dwPort = static_cast<DWORD>(listener.default_port);
-	DWORD dwResponseTimeout = static_cast<DWORD>(listener.default_response_timeout);
+	uint32_t dwPort = static_cast<uint32_t>(listener.default_port);
+	uint32_t dwResponseTimeout = static_cast<uint32_t>(listener.default_response_timeout);
 
 	if (REGLOAD(REGVALUE_START_SP_SLIP_LISTENER, &dwRegStartListener))
 	{

--- a/source/frontends/sdl/CMakeLists.txt
+++ b/source/frontends/sdl/CMakeLists.txt
@@ -11,12 +11,19 @@ find_package(SDL2 REQUIRED)
 # we should use find_package, but Ubuntu does not provide it for SDL2_image
 pkg_search_module(SDL2_IMAGE REQUIRED SDL2_image)
 
-
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # only OpenGL supported on MacOS
   set (SA2_OPENGL ON)
 else()
   option(SA2_OPENGL "Prefer OpenGL over OpenGL ES" OFF)
+endif()
+
+# Force OpenGL on Windows to avoid missing glesv2 in MXE
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  message(STATUS "Forcing SA2_OPENGL ON on Windows to avoid GLES2 dependency")
+  set(SA2_OPENGL ON CACHE BOOL "" FORCE)
+
+  message(STATUS "SDL2_LIBRARIES = ${SDL2_LIBRARIES}")
 endif()
 
 if (SA2_OPENGL)
@@ -27,7 +34,6 @@ else()
     IMGUI_IMPL_OPENGL_ES2
   )
 endif()
-
 
 set(SOURCE_FILES
   main.cpp
@@ -48,12 +54,14 @@ set(HEADER_FILES
   renderer/sdlrendererframe.h
   )
 
-
 target_include_directories(sa2 PRIVATE
   ${SDL2_INCLUDE_DIRS}
   ${SDL2_IMAGE_INCLUDE_DIRS}
-  ${GLES2_INCLUDE_DIRS}
-  )
+)
+
+if (NOT SA2_OPENGL)
+  target_include_directories(sa2 PRIVATE ${GLES2_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(sa2 PRIVATE
   appleii
@@ -65,26 +73,37 @@ target_link_libraries(sa2 PRIVATE
 
   ${SDL2_LIBRARIES}
   ${SDL2_IMAGE_LIBRARIES}
-  ${GLES2_LIBRARIES}
-  OpenGL::GL
-  )
+)
+
+if (NOT SA2_OPENGL)
+  target_link_libraries(sa2 PRIVATE ${GLES2_LIBRARIES})
+endif()
+
+target_link_libraries(sa2 PRIVATE OpenGL::GL)
 
 if (NOT WIN32)
   target_link_libraries(sa2 PUBLIC
     windows
-    )
+  )
 endif()
 
 target_link_directories(sa2 PRIVATE
   ${SDL2_LIBRARY_DIRS}
   ${SDL2_IMAGE_LIBRARY_DIRS}
-  ${GLES2_LIBRARY_DIRS}
-  )
+)
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  target_link_libraries(sa2 PRIVATE ws2_32)
+endif()
+
+if (NOT SA2_OPENGL)
+  target_link_directories(sa2 PRIVATE ${GLES2_LIBRARY_DIRS})
+endif()
 
 target_sources(sa2 PRIVATE
   ${SOURCE_FILES}
   ${HEADER_FILES}
-  )
+)
 
 target_sources(sa2 PRIVATE
   imgui/sdlimguiframe.cpp
@@ -117,17 +136,17 @@ target_sources(sa2 PRIVATE
   ${IMGUI_PATH}/backends/imgui_impl_opengl3.cpp
 
   ${IMGUI_CLUB_PATH}/imgui_memory_editor/imgui_memory_editor.h
-  )
+)
 
 target_include_directories(sa2 PRIVATE
   ${IMGUI_PATH}
   ${IMGUI_PATH}/backends
   ${IMGUI_CLUB_PATH}/imgui_memory_editor
-  )
+)
 
 target_compile_definitions(sa2 PRIVATE
   IMGUI_USER_CONFIG="frontends/sdl/imgui/imconfig.h"
-  )
+)
 
 install(TARGETS sa2
   DESTINATION bin)

--- a/source/frontends/sdl/imgui/sdlimguiframe.cpp
+++ b/source/frontends/sdl/imgui/sdlimguiframe.cpp
@@ -107,7 +107,7 @@ namespace sa2
         myDebuggerFont = io.Fonts->AddFontFromMemoryTTF(
             const_cast<unsigned char *>(debug6502TTF.first), debug6502TTF.second, 13, &fontConfig);
 
-        myIniFileLocation = common2::getConfigFile("imgui.ini");
+        myIniFileLocation = common2::getConfigFile("imgui.ini").string();
         if (myIniFileLocation.empty())
         {
             io.IniFilename = nullptr;

--- a/source/frontends/sdl/main.cpp
+++ b/source/frontends/sdl/main.cpp
@@ -1,3 +1,4 @@
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
 
 #include <iostream>
@@ -165,8 +166,11 @@ void run_sdl(int argc, char *const argv[])
     }
 #endif
 }
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-int main(int argc, char *const argv[])
+int SDL_main(int argc, char *argv[])
 {
     // First we need to start up SDL, and make sure it went ok
     const Uint32 flags = SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_EVENTS;
@@ -192,3 +196,18 @@ int main(int argc, char *const argv[])
 
     return exit;
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef _WIN32
+// Windows-specific wrapper main to satisfy SDL2 linker expecting main
+int main(int argc, char *argv[])
+{
+    return SDL_main(argc, argv);
+}
+#else
+// On non-Windows just use SDL_main as main
+int main(int argc, char *argv[]) __attribute__((alias("SDL_main")));
+#endif


### PR DESCRIPTION
This patch allows windows users to get the full SDL2 goodness of the linux branch, by cross compiling it through dockcross image

I'll add these notes to the readme, but while I still have them, this is for updating the docker image, you don't need to do this as a casual user, the build.sh script will simply download the latest image for cross comiling

```shell
# build the image locally
docker build -t applewin-dockcross-windows-static-x64 .

# log into GHCR
echo ghp_XXXXX... | docker login ghcr.io -u your_github_user --password-stdin

# tag the image
docker tag applewin-dockcross-windows-static-x64 ghcr.io/fujinetwifi/applewin-dockcross-windows-static-x64:latest

# push it
docker push ghcr.io/fujinetwifi/applewin-dockcross-windows-static-x64:latest
```

To build a windows exe, run build.sh with the -w flag:

```shell
# clean + build for windows
./build.sh -cbw

# build just changes for windows
./build.sh -bw
```
